### PR TITLE
Fix help printing when no expression

### DIFF
--- a/scrape_cli/scrape.py
+++ b/scrape_cli/scrape.py
@@ -113,9 +113,10 @@ def main():
 
     # Check that at least one expression is provided by the user (unless using -t option)
     if not args.expression and not args.text:
-        sys.exit("Error: you must provide at least one XPath query or CSS3 selector using the -e option, or use -t to extract text.")
         parser.print_help()
-        sys.exit(1)
+        sys.exit(
+            "Error: you must provide at least one XPath query or CSS3 selector using the -e option, or use -t to extract text."
+        )
 
     # Determine the source of the input: URL, file, or stdin
     if args.html:


### PR DESCRIPTION
## Summary
- print help before exiting when no expression is specified
- remove unreachable `sys.exit(1)`

## Testing
- `python -m py_compile scrape_cli/scrape.py`
- `pytest -q` *(fails: no tests found)*
- `pip install requests lxml cssselect` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_683fef078f5883228cf55a838132a748