### PR TITLE
Fix XPath example quoting

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ or an XPATH query like this one:
 
 ```bash
 curl -L 'https://en.wikipedia.org/wiki/List_of_sovereign_states' -s \
-| scrape -be '//table[contains(@class, 'wikitable')]/tbody/tr/td/b/a'
+| scrape -be "//table[contains(@class, 'wikitable')]/tbody/tr/td/b/a"
 ```
 
 gives you back:


### PR DESCRIPTION
## Summary
- fix quoting in XPath example in README

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_e_683ff08301008322a9611b612d8ec8e5