### PR TITLE
Fix PyInstaller example path

### DIFF
--- a/release_update.md
+++ b/release_update.md
@@ -82,7 +82,7 @@ Se vuoi distribuire un binario precompilato per Linux:
 pip install pyinstaller
 
 # Crea il binario
-pyinstaller --onefile --name scrape scrape_cli/main.py
+pyinstaller --onefile --name scrape scrape_cli/scrape.py
 
 # Il binario sarà in dist/scrape
 # Testalo


### PR DESCRIPTION
## Summary
- fix the PyInstaller command in `release_update.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683ff181195883228c4c3f3d34abd4e0